### PR TITLE
Removing Collection Not Found logs.

### DIFF
--- a/src/main/java/com/tickreader/service/impl/TickServiceImpl.java
+++ b/src/main/java/com/tickreader/service/impl/TickServiceImpl.java
@@ -1178,7 +1178,6 @@ public class TickServiceImpl implements TicksService {
 
                             // Handle resource not found scenario
                             if (TickServiceUtils.isResourceNotFound(cosmosException)) {
-                                logger.warn("Cosmos exception during page fetch: {}", cosmosException.getMessage());
                                 tickRequestContext.setContinuationToken("drained");
                                 logger.warn("No tick data found for date: {}", tickRequestContext.getRequestDateAsString());
 
@@ -1301,7 +1300,6 @@ public class TickServiceImpl implements TicksService {
 
                             // Handle resource not found scenario
                             if (TickServiceUtils.isResourceNotFound(cosmosException)) {
-                                logger.warn("Cosmos exception during page fetch with range filters: {}", cosmosException.getMessage());
                                 tickRequestContext.setContinuationToken("drained");
                                 logger.warn("No tick data found for date: {}", tickRequestContext.getRequestDateAsString());
 
@@ -1421,7 +1419,6 @@ public class TickServiceImpl implements TicksService {
 
                             // Handle resource not found scenario
                             if (TickServiceUtils.isResourceNotFound(cosmosException)) {
-                                logger.warn("Cosmos exception during page fetch with price volume filters: {}", cosmosException.getMessage());
                                 tickRequestContext.setContinuationToken("drained");
                                 logger.warn("No tick data found for date: {}", tickRequestContext.getRequestDateAsString());
 
@@ -1544,7 +1541,6 @@ public class TickServiceImpl implements TicksService {
 
                             // Handle resource not found scenario
                             if (TickServiceUtils.isResourceNotFound(cosmosException)) {
-                                logger.warn("Cosmos exception during page fetch with qualifiers filters: {}", cosmosException.getMessage());
                                 tickRequestContext.setContinuationToken("drained");
                                 logger.warn("No tick data found for date: {}", tickRequestContext.getRequestDateAsString());
 


### PR DESCRIPTION
This pull request updates the `TickServiceImpl` class to streamline logging for scenarios where no tick data is found. Specifically, it removes redundant log messages about Cosmos exceptions during page fetch operations across multiple methods.

Logging improvements:

* `src/main/java/com/tickreader/service/impl/TickServiceImpl.java`: Removed redundant log messages about Cosmos exceptions during page fetch operations in the following methods:
  * `fetchNextPage`
  * `fetchNextPageWithRangeFilters`
  * `fetchNextPageWithPriceVolumeFilters`
  * `fetchNextPageWithQualifiersFilters`