### PR TITLE
Fix range and string filters.

### DIFF
--- a/TickFilter.http
+++ b/TickFilter.http
@@ -1,0 +1,4 @@
+### GET request to example server
+GET http://localhost:8080/ticks/with-qualifiers-filters?rics=MO.DEU&docTypes=TAS,TAQ&totalTicks=50&pinStart=true&startTime=2024-10-07T00:00:00.0000000Z&endTime=2024-10-07T23:59:59.9999999Z&containsFilters=ASK_TONE&notContainsFilters=BID_TONE,GV4_TEXT&notStartsWithFilters=TI&projections=TRDPRC_1,TRDVOL_1,qualifiers
+
+###

--- a/TickQuery.http
+++ b/TickQuery.http
@@ -1,1 +1,1 @@
-GET http://localhost:8080/ticks/sort=messageTimestamp?rics=MSFT&docTypes=TAS,TAQ&totalTicks=100&pinStart=true&startTime=2024-10-07T00:00:00.0000000Z&endTime=2024-10-08T23:59:59.9999999Z&pageSize=100&includeNullValues=false&projections=qualifiers,ricName,recordKey,TRDPRC_1
+GET http://localhost:8080/ticks/sort=messageTimestamp?rics=MSFT&docTypes=TAS,TAQ&totalTicks=10000&pinStart=true&startTime=2024-10-07T00:00:00.0000000Z&endTime=2024-10-08T23:59:59.9999999Z&pageSize=100&includeNullValues=false&projections=qualifiers,ricName,recordKey,trdprc_1

--- a/TickRange1.http
+++ b/TickRange1.http
@@ -1,0 +1,4 @@
+### GET request to example server
+GET http://localhost:8080/ticks/with-range-filters?rics=.HNXMSC&docTypes=TAS,TAQ&totalTicks=50&pinStart=true&startTime=2024-10-07T00:00:00.0000000Z&endTime=2024-10-07T23:59:59.9999999Z&trdprc1Min=10&trdprc1Max=2000.0&trnovrUnsMin=1&trnovrUnsMax=200&projections=TRDPRC_1,TRNOVR_UNS
+
+###

--- a/TickRange2.http
+++ b/TickRange2.http
@@ -1,0 +1,4 @@
+### GET request to example server
+GET http://localhost:8080/ticks/with-price-volume-filters?rics=DEHD8WTW=HVBG&docTypes=TAS,TAQ&totalTicks=50&pinStart=true&startTime=2024-10-07T00:00:00.0000000Z&endTime=2024-10-07T23:59:59.9999999Z&trdprc1Min=100.0&trdprc1Max=200.0&trdvol1Min=10000.0&projections=TRDPRC_1,TRDVOL_1
+
+###

--- a/src/main/java/com/tickreader/service/impl/TickServiceImpl.java
+++ b/src/main/java/com/tickreader/service/impl/TickServiceImpl.java
@@ -1203,7 +1203,6 @@ public class TickServiceImpl implements TicksService {
      * @param endTime End of time range
      * @param pageSize Number of items per page
      * @param pinStart Sorting order flag
-     * @param totalTicks Maximum number of ticks to return
      */
     private void fetchNextPage(
             RicQueryExecutionState ricQueryExecutionState,
@@ -1213,7 +1212,6 @@ public class TickServiceImpl implements TicksService {
             LocalDateTime endTime,
             int pageSize,
             boolean pinStart,
-            int totalTicks,
             List<String> projections) {
 
         // Step 2: Prepare query execution
@@ -1225,15 +1223,13 @@ public class TickServiceImpl implements TicksService {
         SqlQuerySpec querySpec = tickRequestContext.getSqlQuerySpec() != null ?
             tickRequestContext.getSqlQuerySpec() :
             getSqlQuerySpec(
-                tickRequestContext.getTickIdentifier(),
-                docTypes,
+                    docTypes,
                 startTime,
                 endTime,
                 tickRequestContext.getRequestDateAsString(),
                 tickRequestContext.getDateFormat(),
                 pinStart,
-                totalTicks,
-                projections);
+                    projections);
 
         tickRequestContext.setSqlQuerySpec(querySpec);
 
@@ -1302,7 +1298,6 @@ public class TickServiceImpl implements TicksService {
      * @param endTime End of time range
      * @param pageSize Number of items per page
      * @param pinStart Sorting order flag
-     * @param totalTicks Maximum number of ticks to return
      * @param projections List of field names to include in the SELECT clause
      * @param trdprc1Min Minimum value for TRDPRC_1 filter (inclusive)
      * @param trdprc1Max Maximum value for TRDPRC_1 filter (inclusive)
@@ -1317,7 +1312,6 @@ public class TickServiceImpl implements TicksService {
             LocalDateTime endTime,
             int pageSize,
             boolean pinStart,
-            int totalTicks,
             List<String> projections,
             Double trdprc1Min,
             Double trdprc1Max,
@@ -1333,15 +1327,13 @@ public class TickServiceImpl implements TicksService {
         SqlQuerySpec querySpec = tickRequestContext.getSqlQuerySpec() != null ?
             tickRequestContext.getSqlQuerySpec() :
             getSqlQuerySpecWithRangeFilters(
-                tickRequestContext.getTickIdentifier(),
-                docTypes,
+                    docTypes,
                 startTime,
                 endTime,
                 tickRequestContext.getRequestDateAsString(),
                 tickRequestContext.getDateFormat(),
                 pinStart,
-                totalTicks,
-                projections,
+                    projections,
                 trdprc1Min,
                 trdprc1Max,
                 trnovrUnsMin,
@@ -1414,7 +1406,6 @@ public class TickServiceImpl implements TicksService {
      * @param endTime End of time range
      * @param pageSize Number of items per page
      * @param pinStart Sorting order flag
-     * @param totalTicks Maximum number of ticks to return
      * @param projections List of field names to include in the SELECT clause
      * @param trdprc1Min Minimum value for TRDPRC_1 filter (inclusive)
      * @param trdprc1Max Maximum value for TRDPRC_1 filter (inclusive)
@@ -1428,7 +1419,6 @@ public class TickServiceImpl implements TicksService {
             LocalDateTime endTime,
             int pageSize,
             boolean pinStart,
-            int totalTicks,
             List<String> projections,
             Double trdprc1Min,
             Double trdprc1Max,
@@ -1443,15 +1433,13 @@ public class TickServiceImpl implements TicksService {
         SqlQuerySpec querySpec = tickRequestContext.getSqlQuerySpec() != null ?
             tickRequestContext.getSqlQuerySpec() :
             getSqlQuerySpecWithPriceVolumeFilters(
-                tickRequestContext.getTickIdentifier(),
-                docTypes,
+                    docTypes,
                 startTime,
                 endTime,
                 tickRequestContext.getRequestDateAsString(),
                 tickRequestContext.getDateFormat(),
                 pinStart,
-                totalTicks,
-                projections,
+                    projections,
                 trdprc1Min,
                 trdprc1Max,
                 trdvol1Min);
@@ -1637,25 +1625,21 @@ public class TickServiceImpl implements TicksService {
      *   AND C.messageTimestamp < @endTime
      * ORDER BY C.messageTimestamp [ASC|DESC]
      *
-     * @param tickIdentifier Base identifier for the tick (RIC|date)
      * @param docTypes List of document types to filter by
      * @param startTime Start of time range
      * @param endTime End of time range
      * @param localDateAsString Date string for container-specific time bounds
      * @param format Date format pattern
      * @param pinStart If true, sort ascending; if false, sort descending
-     * @param totalTicks Maximum number of ticks to return
      * @return SqlQuerySpec with parameterized query and parameters
      */
     private SqlQuerySpec getSqlQuerySpec(
-            String tickIdentifier,
             List<String> docTypes,
             LocalDateTime startTime,
             LocalDateTime endTime,
             String localDateAsString,
             String format,
             boolean pinStart,
-            int totalTicks,
             List<String> projections) {
 
         // Parse the date string to get container-specific date bounds
@@ -1692,21 +1676,6 @@ public class TickServiceImpl implements TicksService {
             }
         }
         docTypePlaceholders.append(")");
-
-        // Build partition key filter parameters
-//        StringBuilder partitionKeyPlaceholders = new StringBuilder();
-//        partitionKeyPlaceholders.append("(");
-//
-//        // Create parameters for each shard (partition key)
-//        for (int i = 1; i <= this.cosmosDbAccountConfiguration.getShardCountPerRic(); i++) {
-//            String param = "@pk" + i;
-//            parameters.add(new SqlParameter(param, tickIdentifier + "|" + i));
-//            partitionKeyPlaceholders.append(param);
-//            if (i <= this.cosmosDbAccountConfiguration.getShardCountPerRic() - 1) {
-//                partitionKeyPlaceholders.append(", ");
-//            }
-//        }
-//        partitionKeyPlaceholders.append(")");
 
         // Build SELECT clause based on projections
         String selectClause = buildSelectClause("C", projections);
@@ -1746,14 +1715,12 @@ public class TickServiceImpl implements TicksService {
      *   AND C.TRNOVR_UNS >= @trnovrUnsMin AND C.TRNOVR_UNS <= @trnovrUnsMax
      * ORDER BY C.messageTimestamp [ASC|DESC]
      *
-     * @param tickIdentifier Base identifier for the tick (RIC|date)
      * @param docTypes List of document types to filter by
      * @param startTime Start of time range
      * @param endTime End of time range
      * @param localDateAsString Date string for container-specific time bounds
      * @param format Date format pattern
      * @param pinStart If true, sort ascending; if false, sort descending
-     * @param totalTicks Maximum number of ticks to return
      * @param projections List of field names to include in the SELECT clause
      * @param trdprc1Min Minimum value for TRDPRC_1 filter (inclusive)
      * @param trdprc1Max Maximum value for TRDPRC_1 filter (inclusive)
@@ -1762,14 +1729,12 @@ public class TickServiceImpl implements TicksService {
      * @return SqlQuerySpec with parameterized query and parameters
      */
     private SqlQuerySpec getSqlQuerySpecWithRangeFilters(
-            String tickIdentifier,
             List<String> docTypes,
             LocalDateTime startTime,
             LocalDateTime endTime,
             String localDateAsString,
             String format,
             boolean pinStart,
-            int totalTicks,
             List<String> projections,
             Double trdprc1Min,
             Double trdprc1Max,
@@ -1810,21 +1775,6 @@ public class TickServiceImpl implements TicksService {
             }
         }
         docTypePlaceholders.append(")");
-
-        // Build partition key filter parameters
-//        StringBuilder partitionKeyPlaceholders = new StringBuilder();
-//        partitionKeyPlaceholders.append("(");
-//
-//        // Create parameters for each shard (partition key)
-//        for (int i = 1; i <= this.cosmosDbAccountConfiguration.getShardCountPerRic(); i++) {
-//            String param = "@pk" + i;
-//            parameters.add(new SqlParameter(param, tickIdentifier + "|" + i));
-//            partitionKeyPlaceholders.append(param);
-//            if (i <= this.cosmosDbAccountConfiguration.getShardCountPerRic() - 1) {
-//                partitionKeyPlaceholders.append(", ");
-//            }
-//        }
-//        partitionKeyPlaceholders.append(")");
 
         // Build range filter conditions
         StringBuilder rangeFilters = new StringBuilder();
@@ -1891,14 +1841,12 @@ public class TickServiceImpl implements TicksService {
      *   AND C.TRDVOL_1 >= @trdvol1Min
      * ORDER BY C.messageTimestamp [ASC|DESC]
      *
-     * @param tickIdentifier Base identifier for the tick (RIC|date)
      * @param docTypes List of document types to filter by
      * @param startTime Start of time range
      * @param endTime End of time range
      * @param localDateAsString Date string for container-specific time bounds
      * @param format Date format pattern
      * @param pinStart If true, sort ascending; if false, sort descending
-     * @param totalTicks Maximum number of ticks to return
      * @param projections List of field names to include in the SELECT clause
      * @param trdprc1Min Minimum value for TRDPRC_1 filter (inclusive)
      * @param trdprc1Max Maximum value for TRDPRC_1 filter (inclusive)
@@ -1906,14 +1854,12 @@ public class TickServiceImpl implements TicksService {
      * @return SqlQuerySpec with parameterized query and parameters
      */
     private SqlQuerySpec getSqlQuerySpecWithPriceVolumeFilters(
-            String tickIdentifier,
             List<String> docTypes,
             LocalDateTime startTime,
             LocalDateTime endTime,
             String localDateAsString,
             String format,
             boolean pinStart,
-            int totalTicks,
             List<String> projections,
             Double trdprc1Min,
             Double trdprc1Max,
@@ -1953,21 +1899,6 @@ public class TickServiceImpl implements TicksService {
             }
         }
         docTypePlaceholders.append(")");
-
-        // Build partition key filter parameters
-//        StringBuilder partitionKeyPlaceholders = new StringBuilder();
-//        partitionKeyPlaceholders.append("(");
-//
-//        // Create parameters for each shard (partition key)
-//        for (int i = 1; i <= this.cosmosDbAccountConfiguration.getShardCountPerRic(); i++) {
-//            String param = "@pk" + i;
-//            parameters.add(new SqlParameter(param, tickIdentifier + "|" + i));
-//            partitionKeyPlaceholders.append(param);
-//            if (i <= this.cosmosDbAccountConfiguration.getShardCountPerRic() - 1) {
-//                partitionKeyPlaceholders.append(", ");
-//            }
-//        }
-//        partitionKeyPlaceholders.append(")");
 
         // Build range filter conditions
         StringBuilder rangeFilters = new StringBuilder();
@@ -2330,7 +2261,7 @@ public class TickServiceImpl implements TicksService {
         return (ricQueryExecutionState, tickRequestContextPerPartitionKey) -> CompletableFuture.runAsync(() -> {
             try {
                 // Execute the fetch operation
-                fetchNextPage(ricQueryExecutionState, tickRequestContextPerPartitionKey, docTypes, startTime, endTime, pageSize, pinStart, totalTicks, projections);
+                fetchNextPage(ricQueryExecutionState, tickRequestContextPerPartitionKey, docTypes, startTime, endTime, pageSize, pinStart, projections);
             } catch (Exception e) {
                 logger.error("Error in parallel fetch for context {}: {}", tickRequestContextPerPartitionKey.getTickIdentifier(), e.getMessage(), e);
             }
@@ -2369,7 +2300,7 @@ public class TickServiceImpl implements TicksService {
         return (ricQueryExecutionState, tickRequestContextPerPartitionKey)-> CompletableFuture.runAsync(() -> {
             try {
                 // Execute the fetch operation with range filters
-                fetchNextPageWithRangeFilters(ricQueryExecutionState, tickRequestContextPerPartitionKey, docTypes, startTime, endTime, pageSize, pinStart, totalTicks, projections,
+                fetchNextPageWithRangeFilters(ricQueryExecutionState, tickRequestContextPerPartitionKey, docTypes, startTime, endTime, pageSize, pinStart, projections,
                         trdprc1Min, trdprc1Max, trnovrUnsMin, trnovrUnsMax);
             } catch (Exception e) {
                 logger.error("Error in parallel fetch with range filters for context {}: {}", tickRequestContextPerPartitionKey.getTickIdentifier(), e.getMessage(), e);
@@ -2407,7 +2338,7 @@ public class TickServiceImpl implements TicksService {
         return (ricQueryExecutionState, tickRequestContextPerPartitionKey) -> CompletableFuture.runAsync(() -> {
             try {
                 // Execute the fetch operation with price-volume filters
-                fetchNextPageWithPriceVolumeFilters(ricQueryExecutionState, tickRequestContextPerPartitionKey, docTypes, startTime, endTime, pageSize, pinStart, totalTicks, projections,
+                fetchNextPageWithPriceVolumeFilters(ricQueryExecutionState, tickRequestContextPerPartitionKey, docTypes, startTime, endTime, pageSize, pinStart, projections,
                         trdprc1Min, trdprc1Max, trdvol1Min);
             } catch (Exception e) {
                 logger.error("Error in parallel fetch with price-volume filters for context {}: {}", tickRequestContextPerPartitionKey.getTickIdentifier(), e.getMessage(), e);


### PR DESCRIPTION
This pull request introduces several changes to the `TickServiceImpl` implementation and related HTTP query files. The changes focus on simplifying query execution logic, removing unused parameters (`totalTicks` and `tickIdentifier`), and improving partition key handling by directly using the `PartitionKey` object. Additionally, new HTTP query examples have been added for testing various filters.

### Query Logic Simplifications:
* Removed the `totalTicks` parameter across multiple methods (`fetchNextPage`, `fetchNextPageWithRangeFilters`, `fetchNextPageWithPriceVolumeFilters`, `fetchNextPageWithQualifiersFilters`) and associated SQL query specifications. This simplifies the query logic by eliminating unused constraints. [[1]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1206) [[2]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1216) [[3]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1228-L1235) [[4]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1305) [[5]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1320-L1348) [[6]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1436-L1462) [[7]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1557-R1539) [[8]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1653-L1671)
* Updated SQL query specifications to directly use `PartitionKey` instead of constructing partition key filters manually. This improves performance and reduces complexity. [[1]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1320-L1348) [[2]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1436-L1462) [[3]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1557-R1539)

### Removal of Unused Parameters:
* Removed the `tickIdentifier` parameter from SQL query specification methods (`getSqlQuerySpec`, `getSqlQuerySpecWithRangeFilters`, `getSqlQuerySpecWithPriceVolumeFilters`). This parameter was no longer necessary due to the changes in partition key handling. [[1]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1653-L1671) [[2]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1762-L1769) [[3]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1778-L1785) [[4]](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L1909-L1931)

### HTTP Query Examples:
* Added new HTTP query examples (`TickFilter.http`, `TickRange1.http`, `TickRange2.http`) to demonstrate usage of qualifiers, range filters, and price-volume filters. These examples will be useful for testing and validating the updated query logic. [[1]](diffhunk://#diff-f30540fb13e48d04747813fa7d005c4f06ffd8ff3b754f69145345d0a3648ed1R1-R4) [[2]](diffhunk://#diff-8244c6977e817f7d89c27ecaecc0ae7a09efb9794b0bc55c32338a8d3b5d8280R1-R4) [[3]](diffhunk://#diff-8e6ad8a988e5ac180324facfc9e42c81020e2fb6b796b714fc71281c534e2c2aR1-R4)
* Updated an existing HTTP query in `TickQuery.http` to correct case sensitivity in field names (`trdprc_1` instead of `TRDPRC_1`) and adjusted the `totalTicks` value for testing.