### PR TITLE
Provide more threads to query task.

### DIFF
--- a/src/main/java/com/tickreader/service/impl/TickServiceImpl.java
+++ b/src/main/java/com/tickreader/service/impl/TickServiceImpl.java
@@ -109,8 +109,8 @@ public class TickServiceImpl implements TicksService {
         this.cosmosDbAccountConfiguration = cosmosDbAccountConfiguration;
 
         // Initialize thread pool with concurrency level based on CPU count
-        this.queryExecutorService = Executors.newFixedThreadPool(Configs.getCPUCnt() * 4);
-        this.apiExecutorService = Executors.newFixedThreadPool(Configs.getCPUCnt() * 4);
+        this.queryExecutorService = Executors.newFixedThreadPool(Configs.getCPUCnt() * 5);
+        this.apiExecutorService = Executors.newFixedThreadPool(Configs.getCPUCnt() * 5);
         this.perRicExecutorService = Executors.newFixedThreadPool(Configs.getCPUCnt() * 4);
 
         // Configure object mapper to exclude null values from serialization


### PR DESCRIPTION
This pull request includes a minor update to the thread pool configuration in the `TickServiceImpl` class to improve concurrency. Specifically, the number of threads allocated for `queryExecutorService` and `apiExecutorService` has been increased.

Concurrency adjustment:

* [`src/main/java/com/tickreader/service/impl/TickServiceImpl.java`](diffhunk://#diff-4c5fc9cacbb08c299fcae2fd317de8e6140416d46aaa5f1348ac424241b71585L112-R113): Updated the thread pool size for `queryExecutorService` and `apiExecutorService` from `Configs.getCPUCnt() * 4` to `Configs.getCPUCnt() * 5`, enhancing concurrency levels.